### PR TITLE
FIX: Set A2HS display to fullscreen

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -22,5 +22,5 @@
     "start_url": "/index.html",
     "theme_color": "#ffffff",
     "background_color": "#564420",
-    "display": "standalone"
+    "display": "fullscreen"
 }


### PR DESCRIPTION
As discussed on Facebook [1] to hide bars when using Firefox.

1: https://www.facebook.com/groups/204220463286573/permalink/957969914578287/